### PR TITLE
Makes red emergency alert button hover correct

### DIFF
--- a/docroot/sites/all/themes/custom/boston/templates/component/paragraphs-item--document--button-link-dark.tpl.php
+++ b/docroot/sites/all/themes/custom/boston/templates/component/paragraphs-item--document--button-link-dark.tpl.php
@@ -1,4 +1,4 @@
-<a href="<?php print $document_link; ?>" class="btn btn--c">
+<a href="<?php print $document_link; ?>" class="btn btn--c btn--w-hov">
   <?php if (!empty($content['field_title'])): ?>
   <?php print render($content['field_title']); ?>
   <?php else: ?>

--- a/docroot/sites/all/themes/custom/boston/templates/component/paragraphs-item--external-link--button-link-dark.tpl.php
+++ b/docroot/sites/all/themes/custom/boston/templates/component/paragraphs-item--external-link--button-link-dark.tpl.php
@@ -1,3 +1,3 @@
-<a href="<?php print $external_link_path; ?>" class="btn btn--c">
+<a href="<?php print $external_link_path; ?>" class="btn btn--c btn--w-hov">
   <?php print ((!empty($field_title) ? $field_title : $external_link_title)); ?>
 </a>

--- a/docroot/sites/all/themes/custom/boston/templates/component/paragraphs-item--internal-link--button-link-dark.tpl.php
+++ b/docroot/sites/all/themes/custom/boston/templates/component/paragraphs-item--internal-link--button-link-dark.tpl.php
@@ -27,7 +27,7 @@
 $field_title = $content['field_title'][0]['#markup'];
 ?>
 
-<a href="<?php print $internal_link_path; ?>" class="btn btn--c">
+<a href="<?php print $internal_link_path; ?>" class="btn btn--c btn--w-hov">
 <?php if (!empty($field_title)): ?>
   <?php print $field_title; ?>
 <?php else: ?>


### PR DESCRIPTION
Note: Assumes that all use of button_link_dark is against a red
background. As far as I could tell from searching the code, that is the
case, but I don't know if there are other ways to make
button_link_darks.

Depends on CityOfBoston/patterns#295

Fixes #963

#### Fixes [insert bug/issue number]
<br>

#### Changes proposed in this pull request:
*
*

#### Add @mentions of the person or team responsible for reviewing proposed changes
