### PR TITLE
Make map short title optional.

### DIFF
--- a/docroot/sites/all/modules/features/bos_component_map/bos_component_map.features.field_instance.inc
+++ b/docroot/sites/all/modules/features/bos_component_map/bos_component_map.features.field_instance.inc
@@ -290,7 +290,7 @@ function bos_component_map_field_default_field_instances() {
     'fences_wrapper' => 'div_div_div',
     'field_name' => 'field_short_title',
     'label' => 'Short Title',
-    'required' => 1,
+    'required' => 0,
     'settings' => array(
       'linkit' => array(
         'button_text' => 'Search',


### PR DESCRIPTION
#### Fixes https://github.com/CityOfBoston/boston.gov-d7/issues/1163

#### Changes proposed in this pull request:
* Changes `field_short_title` on the maps paragraph bundle from required to optional
