### PR TITLE
Reduces the amount of children Apache can spawn

### DIFF
--- a/docker/limit-apache-children.conf
+++ b/docker/limit-apache-children.conf
@@ -1,0 +1,2 @@
+ServerLimit 6
+

--- a/dockerfiles/drupal
+++ b/dockerfiles/drupal
@@ -37,6 +37,8 @@ RUN ln -s /boston.gov/vendor/bin/drush /usr/local/bin/drush
 
 ADD docker/php.ini /usr/local/etc/php/
 ADD docker/xdebug.ini /usr/local/etc/php/conf.d
+ADD docker/limit-apache-children.conf /etc/apache2/conf-available/
+RUN a2enconf limit-apache-children
 
 # Adds a web console to run drush commands on staging.
 # ZOMG THIS IS NOT FOR PRODUCTION SERIOUSLY NOT


### PR DESCRIPTION
Prevents the container from getting overwhelmed and running out of
memory, especially when processing proxied image requests.

#### Fixes [insert bug/issue number]
<br>

#### Changes proposed in this pull request:
*
*

#### Add @mentions of the person or team responsible for reviewing proposed changes
