### PR TITLE
Fix 'operator not supported' error.

### DIFF
--- a/docroot/sites/all/themes/custom/boston/template.php
+++ b/docroot/sites/all/themes/custom/boston/template.php
@@ -1975,7 +1975,7 @@ function boston_preprocess_field(&$variables, $hook) {
  * Implements hook_preprocess_HOOK().
  */
 function boston_preprocess_field_field_intro_text(&$variables) {
-  $variables['classes_array'] = "";
+  $variables['classes_array'] = [];
   $variables['classes_array'][] = "intro-text";
   $view_mode = $variables['element']['#view_mode'];
   $bundle = $variables['element']['#bundle'];


### PR DESCRIPTION
#### Fixes deployment errors for php7.1
```
 2440201  06/Aug 11:01  error   php  Error: [] operator not supported for strings in boston_preprocess_field_field_intro_text() (line 1979 of /mnt/www/html/bostonuat/docroot/sites/all/themes/custom/boston/template.php). 
```

#### Changes proposed in this pull request:
* Change the initialization of a string to an array
