### PR TITLE
Lifts the custom ServerLimit from 6 to 10 (apache default=16).

### DIFF
--- a/docker/limit-apache-children.conf
+++ b/docker/limit-apache-children.conf
@@ -1,2 +1,2 @@
-ServerLimit 6
+ServerLimit 10
 


### PR DESCRIPTION
#### Fixes [insert bug/issue number]
N/a

#### Changes proposed in this pull request:
* Lifts ServerLimit to 10 from 6.  Was set at 6 for performance tuning on terra-form, but this limit may be causing issues with AJAX on LinkIt.

#### Add @mentions of the person or team responsible for reviewing proposed changes
@finneganh 