### PR TITLE
Deletes /tmp/dump.sql.qz in case it already exists.

### DIFF
--- a/doit
+++ b/doit
@@ -319,6 +319,7 @@ function doitstashdb() {
   drush --root=/boston.gov/docroot sql-dump > /tmp/dump.sql
 
   doitcomment "Gzipping dump."
+  rm -f /tmp/dump.sql.gz
   gzip /tmp/dump.sql
 
   doitcomment "Uploading to S3."


### PR DESCRIPTION
#### Fixes [insert bug/issue number]
N/a

#### Changes proposed in this pull request:
* Adds command to delete any previously existing local zipped db dump.

#### Add @mentions of the person or team responsible for reviewing proposed changes
@finneganh 