### PR TITLE
Fix visibility for anonymous users and loading of libraries - Issue 1191

### DIFF
--- a/docroot/sites/all/modules/features/bos_commissions_search/bos_commissions_search.module
+++ b/docroot/sites/all/modules/features/bos_commissions_search/bos_commissions_search.module
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * Code for the Boston Commissions Search feature.
@@ -6,14 +7,31 @@
 
 include_once 'bos_commissions_search.features.inc';
 
-
 /**
- * Implements hook_init().
+ * Implements hook_preprocess_entity().
  */
-function bos_commissions_search_init() {
-  $commissions_graphql_api_key = variable_get('commissions_graphql_api_key');
-  $commissions_graphql_endpoint = variable_get('commissions_graphql_endpoint');
+function bos_commissions_search_preprocess_entity(&$variables) {
+  if ($variables['entity_type'] == 'paragraphs_item') {
+    if ($variables['elements']['#bundle'] == 'commissions_search') {
+      $commissions_graphql_api_key = variable_get('commissions_graphql_api_key');
+      $commissions_graphql_endpoint = variable_get('commissions_graphql_endpoint');
 
-  drupal_add_js(array('bos_commissions_search' => array('bos_commissions_search_graphql_api_key' => $commissions_graphql_api_key)), array('type' => 'setting'));
-  drupal_add_js(array('bos_commissions_search' => array('bos_commissions_search_graphql_endpoint' => $commissions_graphql_endpoint)), array('type' => 'setting'));
+      drupal_add_js(
+        array(
+          'bos_commissions_search' => array(
+            'bos_commissions_search_graphql_api_key' => $commissions_graphql_api_key,
+          ),
+        ),
+        array('type' => 'setting')
+      );
+      drupal_add_js(
+        array(
+          'bos_commissions_search' => array(
+            'bos_commissions_search_graphql_endpoint' => $commissions_graphql_endpoint,
+          ),
+        ),
+        array('type' => 'setting')
+      );
+    }
+  }
 }

--- a/docroot/sites/default/settings/permissions.settings.php
+++ b/docroot/sites/default/settings/permissions.settings.php
@@ -526,6 +526,7 @@ function acquia_permissions_map() {
     'commission_contact_info',
     'commission_summary',
     'commission_members',
+    'commissions_search',
     'custom_hours_text',
     'daily_hours',
     'discussion_topic',


### PR DESCRIPTION
#### Fixes https://github.com/CityOfBoston/boston.gov-d7/issues/1191

#### Changes proposed in this pull request:
*  Set paragraph permissions
*  Features can't enable options in `field_components` if they haven't been added to bos_core
*  Remove loading libs on every page and look for component - this should limit broken tab issue to only boards & commissions pages.

#### Add @mentions of the person or team responsible for reviewing proposed changes
@davidrkupton 