### PR TITLE
Update atob 1.1.3 to 2.1.0.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -210,10 +210,9 @@
       "optional": true
     },
     "atob": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/atob/-/atob-1.1.3.tgz",
-      "integrity": "sha1-lfE2KbEsOlGl0hWr3OKqnzL4B3M=",
-      "dev": true
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.0.tgz",
+      "integrity": "sha512-SuiKH8vbsOyCALjA/+EINmt/Kdl+TQPrtFgW7XZZcwtryFu9e5kQoX3bjCW6mIvGH1fbeAZZuvwGR5IlBRznGw=="
     },
     "autoprefixer": {
       "version": "6.7.7",
@@ -5601,6 +5600,14 @@
         "resolve-url": "~0.2.1",
         "source-map-url": "~0.3.0",
         "urix": "~0.1.0"
+      },
+      "dependencies": {
+        "atob": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/atob/-/atob-1.1.3.tgz",
+          "integrity": "sha1-lfE2KbEsOlGl0hWr3OKqnzL4B3M=",
+          "dev": true
+        }
       }
     },
     "source-map-url": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "serve": "gulp serve"
   },
   "dependencies": {
+    "atob": "^2.1.0",
     "debug": "^2.6.9",
     "natives": "^1.1.3",
     "run-sequence": "^2.2.0"


### PR DESCRIPTION
#### Changes proposed in this pull request:
*  Upgrades atob npm package: https://nvd.nist.gov/vuln/detail/CVE-2018-3745
