### PR TITLE
Make Procurement Advert UNSPCS number optional.

### DIFF
--- a/docroot/sites/all/modules/features/bos_content_type_procurement_advertisement/bos_content_type_procurement_advertisement.features.field_instance.inc
+++ b/docroot/sites/all/modules/features/bos_content_type_procurement_advertisement/bos_content_type_procurement_advertisement.features.field_instance.inc
@@ -1966,7 +1966,7 @@ function bos_content_type_procurement_advertisement_field_default_field_instance
     'fences_wrapper' => 'div_div_div',
     'field_name' => 'field_unspsc',
     'label' => 'UNSPSC',
-    'required' => 1,
+    'required' => 0,
     'settings' => array(
       'max' => 99999999,
       'min' => 10000000,


### PR DESCRIPTION
#### Fixes https://github.com/CityOfBoston/boston.gov-d7/issues/1204

#### Changes proposed in this pull request:
*  Updates feature to make UNSPCS number field optional instead of required
