### PR TITLE
Update extend for CVE-2018-16492.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1391,8 +1391,8 @@
       }
     },
     "extend": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
       "dev": true
     },


### PR DESCRIPTION
#### Fixes GitHub security flag
https://github.com/CityOfBoston/boston.gov-d7/network/alert/package-lock.json/extend/open
