### PR TITLE
- Added DIV to hold container for new B logo on mobile layouts.

### DIFF
--- a/docroot/sites/all/themes/custom/boston/templates/component/paragraphs-item--hero-image.tpl.php
+++ b/docroot/sites/all/themes/custom/boston/templates/component/paragraphs-item--hero-image.tpl.php
@@ -63,10 +63,5 @@
         <div class="hro-lnk"><?php print render($content['field_grid_link']); ?></div>
       <?php endif; ?>
     </div>
-    <?php if (!isset($content['field_grid_link'])): ?>
-      <div class="the-b the-b--c">
-        <img src="<?php print $asset_url ?>/images/b-light.svg" alt="City of Boston" class="the-b-i">
-      </div>
-    <?php endif; ?>
   </div>
 </div>

--- a/docroot/sites/all/themes/custom/boston/templates/snippets/logo.tpl.php
+++ b/docroot/sites/all/themes/custom/boston/templates/snippets/logo.tpl.php
@@ -1,5 +1,12 @@
 <?php if ($site_name): ?>
   <div class="lo lo--abs">
+    <div class="lo-b">
+      <div class="the-b">
+        <a href="<?php print $front_page; ?>">
+          <img src="<?php print $asset_url ?>/images/b-light.svg?<?php print $cache_buster ?> alt="B Logo" class="the-b-i"  />
+        </a>
+      </div>
+    </div>
     <div class="lo-l">
       <a href="<?php print $front_page; ?>">
         <img src="<?php print $asset_url ?>/images/<?php print $asset_name ?>/logo.svg?<?php print $cache_buster ?>" alt="<?php print $site_name; ?>" class="lo-i" />

--- a/docroot/sites/all/themes/custom/boston/templates/snippets/secondary-nav.tpl.php
+++ b/docroot/sites/all/themes/custom/boston/templates/snippets/secondary-nav.tpl.php
@@ -15,7 +15,7 @@
     <?php foreach ($secondary_menu as $link) { ?>
       <li class="nv-h-l-i"><a href="<?php print url($link['href'], array('absolute' => true)) ?>" title="<?php print $link['title'] ?>" class="nv-h-l-a<?php print !empty($link['always_show']) ? ' nv-h-l-a--k' : '' ?>"><?php print $link['title'] ?></a></li>
     <?php } ?>
-    <li class="tr nv-h-l-i">
+    <li class="nv-h-l-i">
       <a href="#translate" title="Translate" class="nv-h-l-a nv-h-l-a--k--s tr-link">Translate</a>
       <ul class="tr-dd">
         <li><span class="notranslate tr-dd-link tr-dd-link--message">Loading...</span></li>


### PR DESCRIPTION
#### Fixes [insert bug/issue number]
<br>

- Added container DIV for new B logo  on mobile layouts
- Removed TR class so Translate nav item now appears in mobile layouts

#### Changes proposed in this pull request:
*
*

#### Add @mentions of the person or team responsible for reviewing proposed changes
