### PR TITLE
Fix libxslt/xslt-config error on fresh Docker Compose environment

### DIFF
--- a/dockerfiles/drupal
+++ b/dockerfiles/drupal
@@ -12,7 +12,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         git zip unzip bzip2 libbz2-dev rsync nodejs \
         libgd-dev mysql-client openssh-client vim \
-        python python-dev libxslt1.1 && \
+        python python-dev libxslt-dev && \
     docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ && \
     docker-php-ext-install pdo_mysql gd bz2 xsl && \
     pecl install xdebug-2.6.0


### PR DESCRIPTION
#### Fixes [insert bug/issue number]

Hello! Attempting to start a fresh environment with `docker-compose up` in the `develop` branch threw the following error in the `docker-php-ext-install` step:

```
configure: error: xslt-config not found. Please reinstall the libxslt >= 1.1.0 distribution
ERROR: Service 'drupal' failed to build: The command '/bin/sh -c apt-get update &&     apt-get install -y --no-install-recommends         git zip unzip bzip2 libbz2-dev rsync nodejs         libgd-dev mysql-client openssh-client vim         python python-dev libxslt1.1 &&     docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ &&     docker-php-ext-install pdo_mysql gd bz2 xsl &&     pecl install xdebug-2.6.0' returned a non-zero code: 1
```

As I'm brand new to the codebase, I can't be sure using `libxslt-dev` doesn't break anything else – but in my very limited testing, the image and site seem to function as expected. :)

#### Changes proposed in this pull request:
* Install `libxslt-dev` instead of `libxslt1.1` (https://stackoverflow.com/questions/5178416/libxml-install-error-using-pip)

#### Add @mentions of the person or team responsible for reviewing proposed changes
