### PR TITLE
Bash week metrolist updates - Issue 1339

### DIFF
--- a/docroot/sites/all/modules/features/bos_metrolist_affordable_housing/bos_metrolist_affordable_housing.info
+++ b/docroot/sites/all/modules/features/bos_metrolist_affordable_housing/bos_metrolist_affordable_housing.info
@@ -68,6 +68,7 @@ features[variable][] = rh_node_override_metrolist_affordable_housing
 features[variable][] = rh_node_redirect_metrolist_affordable_housing
 features[variable][] = rh_node_redirect_response_metrolist_affordable_housing
 features[variable][] = xmlsitemap_settings_node_metrolist_affordable_housing
+features[views_view][] = metrolist_affordable_housing
 features_exclude[dependencies][ctools] = ctools
 features_exclude[dependencies][entity] = entity
 features_exclude[dependencies][entityreference] = entityreference

--- a/docroot/sites/all/modules/features/bos_metrolist_affordable_housing/bos_metrolist_affordable_housing.views_default.inc
+++ b/docroot/sites/all/modules/features/bos_metrolist_affordable_housing/bos_metrolist_affordable_housing.views_default.inc
@@ -340,7 +340,8 @@ function bos_metrolist_affordable_housing_views_default_views() {
   $handler->display->display_options['sorts']['created']['order'] = 'DESC';
   $handler->display->display_options['filter_groups']['groups'] = array(
     1 => 'AND',
-    2 => 'OR',
+    2 => 'AND',
+    3 => 'OR',
   );
   /* Filter criterion: Content: Published */
   $handler->display->display_options['filters']['status']['id'] = 'status';
@@ -426,6 +427,14 @@ function bos_metrolist_affordable_housing_views_default_views() {
   $handler->display->display_options['filters']['field_mah_zipcode_value']['field'] = 'field_mah_zipcode_value';
   $handler->display->display_options['filters']['field_mah_zipcode_value']['operator'] = '!=';
   $handler->display->display_options['filters']['field_mah_zipcode_value']['group'] = 1;
+  /* Filter criterion: Content: Publish to Metrolist (field_mah_publish_to_metrolist) */
+  $handler->display->display_options['filters']['field_mah_publish_to_metrolist_value']['id'] = 'field_mah_publish_to_metrolist_value';
+  $handler->display->display_options['filters']['field_mah_publish_to_metrolist_value']['table'] = 'field_data_field_mah_publish_to_metrolist';
+  $handler->display->display_options['filters']['field_mah_publish_to_metrolist_value']['field'] = 'field_mah_publish_to_metrolist_value';
+  $handler->display->display_options['filters']['field_mah_publish_to_metrolist_value']['value'] = array(
+    1 => '1',
+  );
+  $handler->display->display_options['filters']['field_mah_publish_to_metrolist_value']['group'] = 1;
   /* Filter criterion: Content: Phone (field_mah_phone) */
   $handler->display->display_options['filters']['field_mah_phone_value']['id'] = 'field_mah_phone_value';
   $handler->display->display_options['filters']['field_mah_phone_value']['table'] = 'field_data_field_mah_phone';
@@ -438,13 +447,17 @@ function bos_metrolist_affordable_housing_views_default_views() {
   $handler->display->display_options['filters']['field_mah_email_value']['field'] = 'field_mah_email_value';
   $handler->display->display_options['filters']['field_mah_email_value']['operator'] = '!=';
   $handler->display->display_options['filters']['field_mah_email_value']['group'] = 2;
-  /* Filter criterion: Content: Publish to Metrolist (field_mah_publish_to_metrolist) */
-  $handler->display->display_options['filters']['field_mah_publish_to_metrolist_value']['id'] = 'field_mah_publish_to_metrolist_value';
-  $handler->display->display_options['filters']['field_mah_publish_to_metrolist_value']['table'] = 'field_data_field_mah_publish_to_metrolist';
-  $handler->display->display_options['filters']['field_mah_publish_to_metrolist_value']['field'] = 'field_mah_publish_to_metrolist_value';
-  $handler->display->display_options['filters']['field_mah_publish_to_metrolist_value']['value'] = array(
-    1 => '1',
-  );
+  /* Filter criterion: Content: Lottery Type (field_mah_lottery_type) */
+  $handler->display->display_options['filters']['field_mah_lottery_type_value_1']['id'] = 'field_mah_lottery_type_value_1';
+  $handler->display->display_options['filters']['field_mah_lottery_type_value_1']['table'] = 'field_data_field_mah_lottery_type';
+  $handler->display->display_options['filters']['field_mah_lottery_type_value_1']['field'] = 'field_mah_lottery_type_value';
+  $handler->display->display_options['filters']['field_mah_lottery_type_value_1']['group'] = 3;
+  /* Filter criterion: Content: Lottery Type (field_mah_lottery_type) */
+  $handler->display->display_options['filters']['field_mah_lottery_type_value']['id'] = 'field_mah_lottery_type_value';
+  $handler->display->display_options['filters']['field_mah_lottery_type_value']['table'] = 'field_data_field_mah_lottery_type';
+  $handler->display->display_options['filters']['field_mah_lottery_type_value']['field'] = 'field_mah_lottery_type_value';
+  $handler->display->display_options['filters']['field_mah_lottery_type_value']['value'] = 'Rental';
+  $handler->display->display_options['filters']['field_mah_lottery_type_value']['group'] = 3;
 
   /* Display: Page */
   $handler = $view->new_display('page', 'Page', 'page');

--- a/docroot/sites/all/modules/features/bos_metrolist_affordable_housing/bos_metrolist_affordable_housing.views_default.inc
+++ b/docroot/sites/all/modules/features/bos_metrolist_affordable_housing/bos_metrolist_affordable_housing.views_default.inc
@@ -204,6 +204,7 @@ function bos_metrolist_affordable_housing_views_default_views() {
     'title' => 'title',
     'field_mah_address' => 'field_mah_address',
     'field_mah_zipcode' => 'field_mah_zipcode',
+    'field_mah_outer_location' => 'field_mah_outer_location',
     'field_mah_neighborhood' => 'field_mah_neighborhood',
     'field_mah_phone' => 'field_mah_phone',
     'field_mah_email' => 'field_mah_email',
@@ -231,8 +232,15 @@ function bos_metrolist_affordable_housing_views_default_views() {
       'separator' => '',
       'empty_column' => 0,
     ),
-    'field_mah_neighborhood' => array(
+    'field_mah_outer_location' => array(
       'sortable' => 0,
+      'default_sort_order' => 'asc',
+      'align' => '',
+      'separator' => '',
+      'empty_column' => 0,
+    ),
+    'field_mah_neighborhood' => array(
+      'sortable' => 1,
       'default_sort_order' => 'asc',
       'align' => '',
       'separator' => '',


### PR DESCRIPTION
#### Fixes #1339 
<br>

#### Changes proposed in this pull request:
* Recreates `bos_metrolist_affordable_housing` feature in order to fix broken update/revert
* Adds filter to only show records with "Lottery Type" of "Rental" or blank on https://www.boston.gov/metrolist/affordable-properties
* Adds sortable column to "Location" 

#### Add @mentions of the person or team responsible for reviewing proposed changes
