### PR TITLE
Adds ssh -T to settings clone script

### DIFF
--- a/scripts/make/apply-settings.sh
+++ b/scripts/make/apply-settings.sh
@@ -12,6 +12,10 @@ DOCROOT=$GIT_ROOT/docroot
 # Fail on error
 set -e
 
+# Lets us know who we have authenticated as, since it doesn’t seem to be
+# cob-deployer. || true because the command exits with 1
+ssh -T git@github.com || true
+
 echo "--------------------------------"
 if [[ "${TRAVIS_BRANCH}" = "settings" ]]; then
   echo "Cloning settings (From settings-develop branch)"


### PR DESCRIPTION
We’re not currently sure what user account the script is authenticating
as, and that’s good information to have.

