### PR TITLE
Add SAML permissions to Site Admin role.

### DIFF
--- a/docroot/sites/hub/settings/permissions.settings.php
+++ b/docroot/sites/hub/settings/permissions.settings.php
@@ -53,6 +53,7 @@ function acquia_permissions_map() {
       'administer profiles',
       'administer taxonomy',
       'administer users',
+      'change saml authentication setting',
       'create application content',
       'create article content',
       'create department_profile content',


### PR DESCRIPTION
#### Fixes https://github.com/CityOfBoston/boston.gov-d7/issues/1386
<br>

#### Changes proposed in this pull request:
*  Updates permissions for Hub so Site Admins can enable SAML for user accounts
